### PR TITLE
edge autocomplete

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ export class Snap extends maptalks.Class {
         this._geometries.push(geometry);
         const self = this;
 
-        const snapTo = function (handleConatainerPoint) {
+        const snapTo = function (handleConatainerPoint, lastContainerPoints) {
             if (!handleConatainerPoint) {
                 return;
             }
@@ -114,7 +114,7 @@ export class Snap extends maptalks.Class {
                     geometries = layer.getGeometries();
                 }
             }
-            return self._nearest(geometries, handleConatainerPoint, this);
+            return self._nearest(geometries, handleConatainerPoint, this, lastContainerPoints);
         };
         // bind adsort function
         geometry.snapTo = snapTo;
@@ -141,7 +141,7 @@ export class Snap extends maptalks.Class {
         delete this._geometries;
     }
 
-    _nearest(geometries, handleConatainerPoint, currentGeometry) {
+    _nearest(geometries, handleConatainerPoint, currentGeometry, lastContainerPoints) {
         // geometries = this._sortGeometries(geometries, handleConatainerPoint);
         let point;
         for (let i = 0, len = geometries.length; i < len; i++) {
@@ -149,7 +149,7 @@ export class Snap extends maptalks.Class {
             if (geometry === currentGeometry) {
                 continue;
             }
-            point = this._nearestGeometry(geometries[i], handleConatainerPoint);
+            point = this._nearestGeometry(geometries[i], handleConatainerPoint, lastContainerPoints);
             if (point) {
                 break;
             }
@@ -160,12 +160,12 @@ export class Snap extends maptalks.Class {
         return this._mousePoint && this._mousePoint.copy();
     }
 
-    _nearestGeometry(geometry, handleConatainerPoint) {
+    _nearestGeometry(geometry, handleConatainerPoint, lastContainerPoints) {
         // multi geometry
         if (geometry.getGeometries) {
             const geometries = geometry.getGeometries();
             for (let i = 0, len = geometries.length; i < len; i++) {
-                const point = this._nearestGeometry(geometries[i], handleConatainerPoint);
+                const point = this._nearestGeometry(geometries[i], handleConatainerPoint, lastContainerPoints);
                 if (point) {
                     return point;
                 }
@@ -225,9 +225,106 @@ export class Snap extends maptalks.Class {
                 POINT.y = point1.y;
             }
         };
+        // 确定点是否在线段上
+        const pointOnLine = (point, startPoint, endPoint) => {
+            const x = point.x;
+            const y = point.y;
+            const x1 = startPoint.x;
+            const y1 = startPoint.y;
+            const x2 = endPoint.x;
+            const y2 = endPoint.y;
+            const dxc = x - x1;
+            const dyc = y - y1;
+            const dxl = x2 - x1;
+            const dyl = y2 - y1;
+            const cross = dxc * dyl - dyc * dxl;
+            if (Math.abs(cross) > 0.1) {
+                return;
+            }
+            if (Math.abs(dxl) >= Math.abs(dyl)) {
+              if (dxl > 0 ? x1 < x && x < x2 : x2 < x && x < x1) {
+                return true;
+              }
+            } else if (dyl > 0 ? y1 < y && y < y2 : y2 < y && y < y1) {
+                return true;
+            }
+        };
+        // 确定点是否在环上，返回所在线段的 index 值
+        const pointOnRing = (ring, point) => {
+            if (!point) {
+                return;
+            }
+            if (point.x === ring[0].x && point.y === ring[0].y) {
+                return [0, 1];
+            }
+            for (let i = 0; i < ring.length - 1; i++) {
+                if (point.x === ring[i + 1].x && point.y === ring[i + 1].y) {
+                    return [i + 1, i + 2];
+                }
+                if (pointOnLine(point, ring[i], ring[i + 1])) {
+                    return [i + 1, i + 1];
+                }
+            }
+        };
+        // 获取环上在当前点击的点和前一个点之间的所有节点
+        const getEffectedVertexOnRing = (ring, oldPoints, newPoint, isRing) => {
+            const [oldPoint, beforeOldPoint] = oldPoints;
+            // 这里已经通过 nearestRing 校验过了环坐标的正确性，不需要再校验一次
+            const ringPoints = ring.map(point => coordinateToContainerPoint(point, map));
+            const oldIndex = pointOnRing(ringPoints, oldPoint);
+            if (!oldIndex) {
+                return;
+            }
+            const newIndex = pointOnRing(ringPoints, newPoint);
+            if (!newIndex) {
+                console.log('seems something wrong');
+                return;
+            }
+            if (oldIndex[0] === newIndex[0] && oldIndex[1] === newIndex[1]) {
+                return;
+            }
+            // 是多边形的环时，需要
+            if (isRing) {
+                let reverse = false;
+                // 使用再之前的一个点来判断自动完成的方向
+                const beforeOldIndex = pointOnRing(ringPoints, beforeOldPoint);
+                if (beforeOldIndex) {
+                    if (beforeOldIndex[0] > oldIndex[0] || beforeOldIndex[1] > oldIndex[1]) {
+                        reverse = true;
+                    } else if (beforeOldIndex[0] === oldIndex[0] && beforeOldIndex[1] === oldIndex[1] && pointOnLine(beforeOldPoint, oldPoint, ringPoints[oldIndex[0]])) {
+                        // 特殊情况，当两个点在同一线段上时，需要再单独计算一次位置
+                        reverse = true;
+                    }
+                }
+                if (oldIndex[0] < newIndex[0] || oldIndex[1] < newIndex[1]) {
+                    if (reverse) {
+                        return ringPoints.slice(1, oldIndex[1]).reverse().concat(ringPoints.slice(newIndex[1]).reverse());
+                    } else {
+                        return ringPoints.slice(oldIndex[1], newIndex[0]);
+                    }
+                } else {
+                    if (reverse) {
+                        return ringPoints.slice(newIndex[1], oldIndex[0]).reverse();
+                    } else {
+                        return ringPoints.slice(oldIndex[1]).concat(ringPoints.slice(1, newIndex[1]));
+                    }
+                }
+            }
+            if (oldIndex[0] < newIndex[0] || oldIndex[1] < newIndex[1]) {
+                return ringPoints.slice(oldIndex[1], newIndex[0]);
+            } else {
+                return ringPoints.slice(newIndex[1], oldIndex[0]).reverse();
+            }
+        };
         if (geometry instanceof maptalks.LineString) {
             const point = nearestRing(coordinates);
             if (point) {
+                if (lastContainerPoints && lastContainerPoints.length) {
+                    const effectedVertex = getEffectedVertexOnRing(coordinates, lastContainerPoints, point);
+                    if (effectedVertex && effectedVertex.length) {
+                        return { point: point.copy(), effectedVertex };
+                    }
+                }
                 return point.copy();
             }
             return;
@@ -236,6 +333,12 @@ export class Snap extends maptalks.Class {
             for (let i = 0, len = coordinates.length; i < len; i++) {
                 const point = nearestRing(coordinates[i]);
                 if (point) {
+                    if (lastContainerPoints && lastContainerPoints.length) {
+                        const effectedVertex = getEffectedVertexOnRing(coordinates[i], lastContainerPoints, point, true);
+                        if (effectedVertex && effectedVertex.length) {
+                            return { point: point.copy(), effectedVertex };
+                        }
+                    }
                     return point.copy();
                 }
             }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/maptalks/maptalks.snap#readme",
   "devDependencies": {
-    "maptalks":"1.0.0-rc.10",
+    "maptalks":"1.0.0-rc.11",
     "cross-env": "^5.1.4",
     "eslint": "^6.2.2",
     "eslint-config-standard": "^14.1.0",

--- a/test/draw-edge.html
+++ b/test/draw-edge.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Map - Display a map</title>
+<style type="text/css">
+    html,
+    body {
+        margin: 0px;
+        height: 100%;
+        width: 100%
+    }
+
+    .container {
+        width: 100%;
+        height: 100%
+    }
+
+    .message {
+        background-color: black;
+        color: white;
+    }
+</style>
+<link rel="stylesheet" href="https://unpkg.com/maptalks/dist/maptalks.css">
+<script type="text/javascript" src="https://unpkg.com/maptalks/dist/maptalks.min.js"></script>
+<script src="../dist/maptalks.snap.js"></script>
+<script type="text/javascript" src="https://unpkg.com/gcoord@0.3.2/dist/gcoord.js"></script>
+
+<body>
+    <div class="message">
+        press ctrl to autocomplete edge
+    </div>
+    <div id="map" class="container"></div>
+    <script src="./drawTool.js"></script>
+    <script src="./base.js"></script>
+    <script>
+        let editGeo;
+        fetch('./data.geojson').then(res => res.json()).then(geojson => {
+            const geos = maptalks.GeoJSON.toGeometry(geojson, function (geo) {
+                if (geo instanceof maptalks.Marker || geo instanceof maptalks.MultiPoint) {
+                    geo.setSymbol(markerSymbol);
+                }
+                if (geo instanceof maptalks.LineString || geo instanceof maptalks.MultiLineString) {
+                    geo.setSymbol(lineSymbol);
+                }
+                if (geo instanceof maptalks.Polygon || geo instanceof maptalks.MultiPolygon) {
+                    geo.setSymbol(fillSymbol);
+                }
+            });
+            layer.addGeometry(geos);
+        });
+
+        const layer1 = new maptalks.VectorLayer('layer1').addTo(map);
+
+        var drawTool = new ExtendDrawTool({
+            mode: 'LineString',
+            'symbol': drawSymbol,
+        }).addTo(map).disable();
+
+        drawTool.on('drawend', function (param) {
+            // console.log(param.geometry);
+            layer1.addGeometry(param.geometry);
+        });
+        drawTool.on('drawstart', function (param) {
+            console.log('reset geometry');
+            snap.effectGeometry(param.tempGeometry);
+            snap.config({
+                fiterGeometries: () => {
+                    return layer.getGeometries().concat(layer1.getGeometries());
+                }
+            })
+        });
+
+        var items = ['LineString', 'Polygon'].map(function (value) {
+            return {
+                item: value,
+                click: function () {
+                    drawTool.setMode(value).enable();
+                }
+            };
+        });
+
+        var toolbar = new maptalks.control.Toolbar({
+            items: [
+                {
+                    item: 'Shape',
+                    children: items
+                },
+                {
+                    item: 'Disable',
+                    click: function () {
+                        drawTool.disable();
+                    }
+                },
+                {
+                    item: 'Clear',
+                    click: function () {
+                        layer1.clear();
+                    }
+                }
+            ]
+        }).addTo(map);
+
+
+
+
+    </script>
+</body>
+
+</html>

--- a/test/draw-edge.html
+++ b/test/draw-edge.html
@@ -55,6 +55,7 @@
         var drawTool = new ExtendDrawTool({
             mode: 'LineString',
             'symbol': drawSymbol,
+            edgeAutoComplete: false
         }).addTo(map).disable();
 
         drawTool.on('drawend', function (param) {
@@ -70,6 +71,9 @@
                 }
             })
         });
+        drawTool.on('mousemove', function (e) {
+            drawTool.config({ edgeAutoComplete: e.domEvent.ctrlKey })
+        })
 
         var items = ['LineString', 'Polygon'].map(function (value) {
             return {

--- a/test/drawTool.js
+++ b/test/drawTool.js
@@ -26,7 +26,7 @@ class ExtendDrawTool extends maptalks.DrawTool {
             if (snapTo && isFunction(snapTo)) {
                 let containerPoint = event.containerPoint;
                 const lastContainerPoints = [];
-                if (event.domEvent.ctrlKey) {
+                if (this.options.edgeAutoComplete) {
                     const lastCoord = this._clickCoords[(this._historyPointer || 1) - 1];
                     lastContainerPoints.push(map._prjToContainerPoint(lastCoord));
                     const beforeLastCoord = this._clickCoords[(this._historyPointer || 1) - 2];
@@ -50,6 +50,10 @@ class ExtendDrawTool extends maptalks.DrawTool {
             this._historyPointer = this._clickCoords.length;
             event.drawTool = this;
             registerMode['update'](this.getMap().getProjection(), this._clickCoords, this._geometry, event);
+            if (this.getMode() === 'point') {
+                this.endDraw(event);
+                return;
+            }
             /**
              * drawvertex event.
              *
@@ -83,7 +87,11 @@ class ExtendDrawTool extends maptalks.DrawTool {
      */
     _mouseMoveHandler(event) {
         const map = this.getMap();
-        if (!this._geometry || !map || map.isInteracting()) {
+        if (!map || map.isInteracting()) {
+            return;
+        }
+        if (this.getMode() === 'point' && !this._geometry) {
+            this._createGeometry(event);
             return;
         }
         let containerPoint = this._getMouseContainerPoint(event);
@@ -96,7 +104,7 @@ class ExtendDrawTool extends maptalks.DrawTool {
         const snapTo = this._geometry.snapTo;
         if (snapTo && isFunction(snapTo)) {
             const lastContainerPoints = [];
-            if (event.domEvent.ctrlKey) {
+            if (this.options.edgeAutoComplete) {
                 const lastCoord = this._clickCoords[(this._historyPointer || 1) - 1];
                 lastContainerPoints.push(map._prjToContainerPoint(lastCoord));
                 const beforeLastCoord = this._clickCoords[(this._historyPointer || 1) - 2];

--- a/test/drawTool.js
+++ b/test/drawTool.js
@@ -1,0 +1,142 @@
+const isFunction = maptalks.Util.isFunction;
+const isNil = maptalks.Util.isNil;
+
+class ExtendDrawTool extends maptalks.DrawTool {
+    _clickHandler(event) {
+        const map = this.getMap();
+        const registerMode = this._getRegisterMode();
+        // const coordinate = event['coordinate'];
+        // dbclick will trigger two click
+        if (this._clickCoords && this._clickCoords.length) {
+            const len = this._clickCoords.length;
+            const prjCoord = map._pointToPrj(event['point2d']);
+            if (this._clickCoords[len - 1].equals(prjCoord)) {
+                return;
+            }
+        }
+        if (!this._geometry) {
+            this._createGeometry(event);
+        } else {
+            let prjCoord = map._pointToPrj(event['point2d']);
+            if (!isNil(this._historyPointer)) {
+                this._clickCoords = this._clickCoords.slice(0, this._historyPointer);
+            }
+            // for snap effect
+            const snapTo = this._geometry.snapTo;
+            if (snapTo && isFunction(snapTo)) {
+                let containerPoint = event.containerPoint;
+                const lastContainerPoints = [];
+                if (event.domEvent.ctrlKey) {
+                    const lastCoord = this._clickCoords[(this._historyPointer || 1) - 1];
+                    lastContainerPoints.push(map._prjToContainerPoint(lastCoord));
+                    const beforeLastCoord = this._clickCoords[(this._historyPointer || 1) - 2];
+                    if (beforeLastCoord) {
+                        lastContainerPoints.push(map._prjToContainerPoint(beforeLastCoord));
+                    }
+                }
+                const snapResult = snapTo(containerPoint, lastContainerPoints);
+                containerPoint = (snapResult.effectedVertex ? snapResult.point : snapResult) || containerPoint;
+                prjCoord = map._containerPointToPrj(containerPoint);
+                if (snapResult.effectedVertex) {
+                    const additionVertex = snapResult.effectedVertex.map(vertex => map._containerPointToPrj(vertex));
+                    this._clickCoords = this._clickCoords.concat(additionVertex);
+                }
+                // ensure snap won't trigger again when dblclick
+                if (this._clickCoords[this._clickCoords.length - 1].equals(prjCoord)) {
+                    return;
+                }
+            }
+            this._clickCoords.push(prjCoord);
+            this._historyPointer = this._clickCoords.length;
+            event.drawTool = this;
+            registerMode['update'](this.getMap().getProjection(), this._clickCoords, this._geometry, event);
+            /**
+             * drawvertex event.
+             *
+             * @event DrawTool#drawvertex
+             * @type {Object}
+             * @property {String} type - drawvertex
+             * @property {DrawTool} target - draw tool
+             * @property {Geometry} geometry - geometry drawn
+             * @property {Coordinate} coordinate - coordinate of the event
+             * @property {Point} containerPoint  - container point of the event
+             * @property {Point} viewPoint       - view point of the event
+             * @property {Event} domEvent                 - dom event
+             */
+            if (this._clickCoords.length <= 1) {
+                this._fireEvent('drawstart', event);
+            } else {
+                this._fireEvent('drawvertex', event);
+            }
+
+            if (registerMode['clickLimit'] && registerMode['clickLimit'] === this._historyPointer) {
+                // registerMode['update']([coordinate], this._geometry, event);
+                this.endDraw(event);
+            }
+        }
+    }
+
+    /**
+     * handle mouse move event
+     * @param event
+     * @private
+     */
+    _mouseMoveHandler(event) {
+        const map = this.getMap();
+        if (!this._geometry || !map || map.isInteracting()) {
+            return;
+        }
+        let containerPoint = this._getMouseContainerPoint(event);
+        if (!this._isValidContainerPoint(containerPoint)) {
+            return;
+        }
+        let prjCoord = map._pointToPrj(event['point2d']);
+        // for snap effect
+        let snapAdditionVertex = [];
+        const snapTo = this._geometry.snapTo;
+        if (snapTo && isFunction(snapTo)) {
+            const lastContainerPoints = [];
+            if (event.domEvent.ctrlKey) {
+                const lastCoord = this._clickCoords[(this._historyPointer || 1) - 1];
+                lastContainerPoints.push(map._prjToContainerPoint(lastCoord));
+                const beforeLastCoord = this._clickCoords[(this._historyPointer || 1) - 2];
+                if (beforeLastCoord) {
+                    lastContainerPoints.push(map._prjToContainerPoint(beforeLastCoord));
+                }
+            }
+            const snapResult = snapTo(containerPoint, lastContainerPoints);
+            containerPoint = (snapResult.effectedVertex ? snapResult.point : snapResult) || containerPoint;
+            prjCoord = map._containerPointToPrj(containerPoint);
+            if (snapResult.effectedVertex) {
+                snapAdditionVertex = snapResult.effectedVertex.map(vertex => map._containerPointToPrj(vertex));
+            }
+        }
+        const projection = map.getProjection();
+        event.drawTool = this;
+        const registerMode = this._getRegisterMode();
+        if (this._shouldRecordHistory(registerMode.action)) {
+            const path = this._clickCoords.slice(0, this._historyPointer);
+            if (path && path.length > 0 && prjCoord.equals(path[path.length - 1])) {
+                return;
+            }
+            registerMode['update'](projection, path.concat(snapAdditionVertex, [prjCoord]), this._geometry, event);
+        } else {
+            // free hand mode
+            registerMode['update'](projection, prjCoord, this._geometry, event);
+        }
+        /**
+         * mousemove event.
+         *
+         * @event DrawTool#mousemove
+         * @type {Object}
+         * @property {String} type - mousemove
+         * @property {DrawTool} target - draw tool
+         * @property {Geometry} geometry - geometry drawn
+         * @property {Coordinate} coordinate - coordinate of the event
+         * @property {Point} containerPoint  - container point of the event
+         * @property {Point} viewPoint       - view point of the event
+         * @property {Event} domEvent                 - dom event
+         */
+        this._fireEvent('mousemove', event);
+    }
+}


### PR DESCRIPTION
在绘制地理元素时，如果前一个绘制的点也在当前鼠标所吸附到的线/环上时，自动将两点中间的节点添加到当前绘制的地理元素中。

1. 仅绘制时可用，编辑时无效
2. 按 Ctrl 键才自动完成，否则仅吸附鼠标所在点
3. 当吸附一个环时，通过再之前的一个点计算截取的方向
4. 由于当确定了吸附的元素之后再计算自动完成，性能损耗是一次性的，可忽略不计

演示见 test/draw-edge.html；由于需要返回额外的点，需要修改 DrawTool.js，否则必须自定义扩展，见 test/drawTool.js。烦请先审阅此 PR，如果此功能可以合并，我再给 maptalks.js 提 PR